### PR TITLE
Port correction for notification service on docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -141,7 +141,7 @@ services:
     depends_on:
       - identity
     ports:
-      - 9005:9005
+      - 9006:9006
       - 9015:9015
   # /CSHR
 


### PR DESCRIPTION
This change changes the port exposed by the `docker-compose` file for the `notification-service` from `9005` to the correct one, `9006`