### PR TITLE
LC-1866: Fix dev environment issues

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
       - notification-service
     build:
       context: apps/identity-management
+      dockerfile: Dockerfile.dev
     ports:
       - 8081:8081
     command: java -jar /data/app.jar
@@ -79,9 +80,7 @@ services:
       - civil-servant-registry
       - identity
       - learning-catalogue
-      - mongodb
       - mysql
-      - learning-locker-xapi
     ports:
       - 9000:9000
       - 9010:9010


### PR DESCRIPTION
This change:

* Removes remaining references to `mongodb` and `learning-locker-xapi`
* Sets dockerfile of `identity-management` from `Dockerfile` to `Dockerfile.dev`.