### PR TITLE
Dev env updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Learning Locker will be set up as normal and should not be changed. It is extrem
 
 Redis and MySQL will start up in their own containers as dependencies for all of the other applications in the compose file. Once up, the MySQL container will bind volumes to the local machine to preserve data inbetween starting/stopping the dev-env.
 
+##### Populating the ElasticSearch (learning catalogue) database
+
+Use this command to add test courses to the ES database:
+
+```
+curl -XPOST "http://localhost:9200/courses/_doc/_bulk" -H "Content-Type: application/json" --data-binary "@apps/lpg-learning-catalogue/data/data.json"
+```
+
 ### After up
 
 Once all of the apps have successfully started within Docker, the website can be accessed by visiting `localhost:3001` in a web browser. 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,9 +96,11 @@ services:
     depends_on:
       - identity
       - elasticsearch
+      - storage
     ports:
       - 9001:9001
       - 9091:9091
+    restart: always
 
   civil-servant-registry:
     # container_name: civil-servant-registry
@@ -147,11 +149,20 @@ services:
   # # Data
   elasticsearch:
     # container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.13
     ports:
       - 9200:9200
       - 9300:9300
-    command: 'elasticsearch -E cluster.name=local -E discovery.type=single-node'
+    command: 'elasticsearch'
+    env_file:
+      - ./env/elasticsearch.env
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.17.13
+    ports:
+      - 5601:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
 
   redis:
     # container_name: redis
@@ -170,6 +181,13 @@ services:
     command: mysqld --init-file="/tmp/database/setup.sql"
     environment: 
       - MYSQL_ROOT_PASSWORD=my-secret-pw
+
+  storage:
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002
 
    #/Data
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -149,7 +149,7 @@ services:
   # # Data
   elasticsearch:
     # container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.2
     ports:
       - 9200:9200
       - 9300:9300
@@ -158,7 +158,9 @@ services:
       - ./env/elasticsearch.env
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.13
+    image: docker.elastic.co/kibana/kibana:8.4.2
+    depends_on:
+      - elasticsearch
     ports:
       - 5601:5601
     environment:

--- a/env/elasticsearch.env
+++ b/env/elasticsearch.env
@@ -1,0 +1,2 @@
+cluster.name=local
+discovery.type=single-node

--- a/env/elasticsearch.env
+++ b/env/elasticsearch.env
@@ -1,2 +1,3 @@
 cluster.name=local
 discovery.type=single-node
+xpack.security.enabled=false

--- a/env/learning-catalogue.env
+++ b/env/learning-catalogue.env
@@ -4,3 +4,8 @@ REGISTRY_SERVICE_URL=http://civil-servant-registry:9002
 LEARNER_RECORD_URL=http://learner-record:9000
 jwt_key=key
 JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9011
+AZURE_STORAGE_CONNECTION_STRING=AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://storage:10000/devstoreaccount1;QueueEndpoint=http://storage:10001/devstoreaccount1;TableEndpoint=http://storage:10002/devstoreaccount1;
+ES_HOST=elasticsearch
+ES_PORT=9200
+ES_PROTOCOL=http
+ELASTICSEARCH_READ_TIMEOUT=10000


### PR DESCRIPTION
This change:

* Added necessary environment variables to `learning-catalogue.env` to override the default ones when running with `docker-compose` 
* Upgraded ElasticSearch to version 7.17.13, which is closer to the version used in Elastic Cloud
* Created a local Kibana service bound to the ElasticSearch instance, for easier navigation.
* Created local Blob Storage instance service in `docker-compose` using Azurite. Included a `AZURE_STORAGE_CONNECTION_STRING` variable in `learning-catalogue.env`
* Included instructions in `README` on how to load test data in ElasticSearch.